### PR TITLE
fix cli commentary 'mvn exec'

### DIFF
--- a/src/main/resources/archetype-resources/src/main/java/cli/NoraUiCLI.java
+++ b/src/main/resources/archetype-resources/src/main/java/cli/NoraUiCLI.java
@@ -17,14 +17,14 @@ import ${package}.indus.Counter;
 import ${package}.utils.${robotName}Context;
 
 public class NoraUiCLI {
-    
+
     /**
      * Java sample:
      * cd target\classes
      * java -cp . ${package}.cli.NoarUiCLI -h
      * Maven sample:
-     * mvn exec:java -Dexec.mainClass="${package}.cli.NoarUiCLI" -Dexec.args="-h"
-     * 
+     * mvn exec:java -Dexec.mainClass="${package}.cli.NoraUiCLI" -Dexec.args="-h"
+     *
      * @param args
      *            is list of args (-h, --verbose, --interactiveMode, -f, -s, -u, -d, -k, -a, -m, -fi and -re (optional))
      * @throws TechnicalException


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Correction of the "mvn exec" comment in the NoraUiCLI class.

## Details

Change from `mainClass="${package}.cli.NoarUiCLI"` to `mainClass="${package}.cli.NoraUiCLI"`

## Motivation and Context

Make functional the use of the command described in comment.

## How Has This Been Tested?

Test by using `mvn` :

```
Apache Maven 3.6.3
Maven home: /usr/share/maven
Java version: 11.0.15, vendor: Private Build, runtime: /usr/lib/jvm/java-11-openjdk-amd64
Default locale: fr_FR, platform encoding: UTF-8
OS name: "linux", version: "5.13.0-44-generic", arch: "amd64", family: "unix"
```

## Screenshots (if appropriate):

Not applicable

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

Not applicable

- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
